### PR TITLE
Optimized extension installation in docker builds

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -13,6 +13,7 @@ ENV CKAN_DIR=${SRC_DIR}/ckan \
     DATA_DIR=${APP_DIR}/data
 WORKDIR ${APP_DIR}
 COPY pip.conf /etc/pip.conf
+RUN pip install --upgrade pip
 
 
 #
@@ -216,6 +217,14 @@ FROM ckan_build AS production
 
 # Install uwsgitop for stats analyzing
 RUN pip install uwsgitop
+
+# Install extension requirements (order in ascending probability of changes)
+COPY ckanext/ckanext-dcat/requirements.txt ${EXT_DIR}/ckanext-dcat/requirements.txt
+COPY ckanext/ckanext-fluent/requirements.txt ${EXT_DIR}/ckanext-fluent/requirements.txt
+COPY ckanext/ckanext-markdown_editor/requirements.txt ${EXT_DIR}/ckanext-markdown_editor/requirements.txt
+COPY ckanext/ckanext-pages/requirements.txt ${EXT_DIR}/ckanext-pages/requirements.txt
+COPY ckanext/ckanext-registrydata/requirements.txt ${EXT_DIR}/ckanext-registrydata/requirements.txt
+RUN ${SCRIPT_DIR}/install_extension_requirements.sh
 
 # copy extensions
 COPY --from=modules_build ${EXT_DIR} ${EXT_DIR}

--- a/ckan/README.md
+++ b/ckan/README.md
@@ -1,0 +1,11 @@
+# Registrydata CKAN container
+
+## Developer notes
+
+### Adding a CKAN extension
+
+1. Add the extension directory to `ckanext`
+1. Add copying the extension's requirements files to production image in `Dockerfile`
+1. Add installing the extension's requirements in `scripts/install_extension_requirements.sh`
+1. Add installing and configuring the extension in `scripts/install_extensions.sh`
+

--- a/ckan/pip.conf
+++ b/ckan/pip.conf
@@ -1,3 +1,4 @@
 [global]
 extra-index-url = https://alpine-wheels.github.io/index
 no-cache-dir = True
+root-user-action = ignore

--- a/ckan/scripts/entrypoint_ckan.sh
+++ b/ckan/scripts/entrypoint_ckan.sh
@@ -13,6 +13,7 @@ export CKAN_SYSADMIN_EMAIL="${SYSADMIN_EMAIL}"
 # install extensions (DEV_MODE)
 if [[ "${DEV_MODE}" == "true" ]]; then
     echo "entrypoint_ckan - installing extensions because DEV_MODE = 'true' ..."
+    sudo -E ${SCRIPT_DIR}/install_extension_requirements.sh
     sudo -E ${SCRIPT_DIR}/install_extensions.sh
 fi
 

--- a/ckan/scripts/entrypoint_cron.sh
+++ b/ckan/scripts/entrypoint_cron.sh
@@ -12,6 +12,7 @@ done
 # install extensions (DEV_MODE)
 if [[ "${DEV_MODE}" == "true" ]]; then
   echo "entrypoint_cron - installing extensions because DEV_MODE = 'true' ..."
+  sudo -E ${SCRIPT_DIR}/install_extension_requirements.sh
   sudo -E ${SCRIPT_DIR}/install_extensions.sh
 fi
 

--- a/ckan/scripts/install_extension_requirements.sh
+++ b/ckan/scripts/install_extension_requirements.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+echo "install_extension_requirements ..."
+
+pip_install() {
+  if [[ ! -f "$1" ]]; then
+    echo "pip_install: skipping $1 because file does not exist!"
+    return 0
+  fi
+
+  echo "pip_install: installing $1 ..."
+
+  pip install -r "$1"
+}
+
+# install extension requirements
+pip_install "${EXT_DIR}/ckanext-dcat/requirements.txt"
+pip_install "${EXT_DIR}/ckanext-fluent/requirements.txt"
+pip_install "${EXT_DIR}/ckanext-scheming/requirements.txt"
+pip_install "${EXT_DIR}/ckanext-pages/requirements.txt"
+pip_install "${EXT_DIR}/ckanext-markdown_editor/requirements.txt"
+pip_install "${EXT_DIR}/ckanext-registrydata/requirements.txt"

--- a/ckan/scripts/install_extensions.sh
+++ b/ckan/scripts/install_extensions.sh
@@ -3,32 +3,6 @@ set -e
 
 echo "install_extensions ..."
 
-pip_install() {
-  if [[ ! -f "$1" ]]; then
-    echo "pip_install: skipping $1 because file does not exist!"
-    return 0
-  fi
-
-  echo "pip_install: installing $1 ..."
-
-  pip install -r "$1"
-}
-
-# install extension requirements
-pip_install "${EXT_DIR}/ckanext-dcat/requirements.txt"
-pip_install "${EXT_DIR}/ckanext-fluent/requirements.txt"
-pip_install "${EXT_DIR}/ckanext-registrydata/requirements.txt"
-pip_install "${EXT_DIR}/ckanext-scheming/requirements.txt"
-pip_install "${EXT_DIR}/ckanext-pages/requirements.txt"
-pip_install "${EXT_DIR}/ckanext-markdown_editor/requirements.txt"
-
-# install extension pip requirements
-pip_install "${EXT_DIR}/ckanext-dcat/pip-requirements.txt"
-pip_install "${EXT_DIR}/ckanext-fluent/pip-requirements.txt"
-pip_install "${EXT_DIR}/ckanext-registrydata/pip-requirements.txt"
-pip_install "${EXT_DIR}/ckanext-scheming/pip-requirements.txt"
-pip_install "${EXT_DIR}/ckanext-markdown_editor/pip-requirements.txt"
-
 # install extensions
 pip install -e ${EXT_DIR}/ckanext-dcat \
     -e ${EXT_DIR}/ckanext-fluent \


### PR DESCRIPTION
- Upgrade pip in configured_base
- Disabled warnings about root pip installs in containers
- Production build: Install extension requirements before copying extension contents to avoid reinstalling them all on every extension change
- Split `install_extensions.sh` into two scripts