### PR TITLE
REKDAT-29: Local unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ docker/docker-compose.override.yml
 
 # Local environment
 docker/.env
+
+# CKAN extension unit testing configuration
+ckan/ckanext/ckan

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -179,6 +179,7 @@ ENV DEV_MODE=true
 RUN \
   # install ckan dev requirements
   pip install -r ${SRC_DIR}/ckan/dev-requirements.txt && \
+  pip install pytest-ckan && \
   # enable sudo for ckan user
   apk add --no-cache sudo && \
   addgroup sudo && \

--- a/ckan/UNIT_TESTING.md
+++ b/ckan/UNIT_TESTING.md
@@ -1,0 +1,46 @@
+# Running unit tests in Docker
+
+## Environment setup
+
+**1. Add test instance of Solr to your docker-compose.override.yml**
+
+```yaml
+solr-test:
+  image: registrydata/solr:latest
+  build:
+    context: ./solr
+  expose:
+    - 8983
+  networks:
+    - backend
+  volumes:
+    - solr_test_data:/opt/solr/server/solr/ckan/data
+  restart: unless-stopped
+```
+
+**2. Add configuration to ckanext/ckan/test-core.ini**
+
+```ini
+[app:main]
+use = config:../../src/ckan/test-core.ini
+sqlalchemy.url = postgresql://ckan:ckan_pass@postgres/ckan_test
+solr_url = http://solr-test:8983/solr/ckan
+ckan.redis.url = redis://redis:6379/1
+```
+
+**3. Start the solr-test container**
+`docker-compose -p registrydata up -d solr-test`
+
+**4. Start a shell in ckan-container**
+`docker exec -it registrydata-ckan-1 bash`
+
+**5. Run pytest**
+```bash
+cd ckanext/ckanext-registrydata
+pytest
+```
+
+## Troubleshooting
+
+### Database not found
+The test database is created in `ckan/scripts/init_ckan.sh` so it happens only once. Drop the container and associated volumes and redeploy them.

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/tests/test_plugin.py
@@ -77,7 +77,7 @@ def minimal_dataset_with_one_resource_fields(user):
     )
 
 
-@pytest.mark.usefixtures("clean_db", "with_plugins")
+@pytest.mark.usefixtures("clean_db", "clean_index", "with_plugins")
 def test_minimal_dataset():
     dataset_fields = minimal_dataset_with_one_resource_fields(Sysadmin())
     Dataset(**dataset_fields)

--- a/ckan/scripts/init_ckan.sh
+++ b/ckan/scripts/init_ckan.sh
@@ -16,6 +16,10 @@ python prerun.py || { echo '[CKAN prerun] FAILED. Exiting...' ; exit 1; }
 echo "Upgrade CKAN database ..."
 ckan -c ${APP_DIR}/production.ini db upgrade
 
+if [[ "${DEV_MODE}" == "true" ]]; then
+  echo "Initializing test database"
+  echo ${DB_CKAN_PASS} | psql -h ${DB_HOST} -U ${DB_CKAN_USER} -c "CREATE DATABASE ckan_test OWNER ${DB_CKAN_USER} ENCODING 'utf-8'"
+fi
 # init ckan extensions
 #echo "init ckan extensions ..."
 


### PR DESCRIPTION
- Added instructions for running unit tests locally
- Added gitignore for local unit testing files
- Added `pytest-ckan` to development CKAN image
- Added initializing test database to `init_ckan.sh`
- Fixed a failing unit test (missed cleaning search index)