### PR TITLE
Add required permission for gha deployment

### DIFF
--- a/cloudformation/github-actions-stack.yml
+++ b/cloudformation/github-actions-stack.yml
@@ -62,6 +62,20 @@ Resources:
               - Effect: Allow
                 Action: "ecr:GetAuthorizationToken"
                 Resource: "*"
+        - PolicyName: cfn-access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "cloudformation:*"
+                Resource: "*"
+        - PolicyName: sts-cdk-assume-permission
+          PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action: "sts:AssumeRole"
+                  Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/cdk-*"
 
   BuildRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
GHA requires permission to modify cloudformation and assume cdk role for deployments.