### PR TITLE
REKDAT-33: Add certificate stacks for dev and prod

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -8,6 +8,7 @@ import {KmsKeyStack} from "../lib/kms-key-stack";
 import {LambdaStack} from "../lib/lambda-stack"
 import {LoadBalancerStack} from "../lib/load-balancer-stack";
 import {SubDomainStack} from "../lib/sub-domain-stack";
+import {CertificateStack} from "../lib/certificate-stack";
 
 const app = new cdk.App();
 
@@ -91,6 +92,14 @@ const SubDomainStackDev = new SubDomainStack(app, 'SubDomainStack-dev', {
     subDomainName: "dev"
 })
 
+const CertificateStackDev = new CertificateStack(app, 'CertificateStack-dev', {
+    env: {
+        account: devStackProps.account,
+        region: devStackProps.region,
+    },
+    zone: SubDomainStackDev.subZone
+})
+
 
 // Production
 
@@ -140,4 +149,13 @@ const LambdaStackProd = new LambdaStack(app, 'LambdaStack-prod', {
   ckanInstance: DatabaseStackProd.ckanInstance,
   ckanAdminCredentials: DatabaseStackProd.ckanAdminCredentials,
   vpc: VpcStackProd.vpc,
+})
+
+
+const CertificateStackProd = new CertificateStack(app, 'CertificateStack-prod', {
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  zone: DomainStackProd.publicZone
 })

--- a/cdk/lib/certificate-stack-props.ts
+++ b/cdk/lib/certificate-stack-props.ts
@@ -1,0 +1,5 @@
+import {aws_route53, StackProps} from "aws-cdk-lib";
+
+export interface CertificateStackProps extends StackProps {
+    zone: aws_route53.IPublicHostedZone;
+}

--- a/cdk/lib/certificate-stack.ts
+++ b/cdk/lib/certificate-stack.ts
@@ -1,0 +1,15 @@
+import {Stack, aws_certificatemanager as acm} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import {CertificateStackProps} from "./certificate-stack-props";
+
+export class CertificateStack extends Stack {
+    readonly certificate: acm.ICertificate;
+    constructor(scope: Construct, id: string, props: CertificateStackProps) {
+        super(scope, id, props);
+
+        this.certificate = new acm.Certificate(this, 'Certificate', {
+            domainName: props.zone.zoneName,
+            validation: acm.CertificateValidation.fromDns(props.zone)
+        })
+    }
+}

--- a/cdk/lib/domain-stack.ts
+++ b/cdk/lib/domain-stack.ts
@@ -4,11 +4,11 @@ import {aws_iam, aws_route53} from "aws-cdk-lib";
 import {DomainStackProps} from "./domain-stack-props";
 
 export class DomainStack extends cdk.Stack {
+  readonly publicZone: aws_route53.PublicHostedZone;
   constructor(scope: Construct, id: string, props: DomainStackProps) {
-
     super(scope, id, props);
 
-    const publicZone = new aws_route53.PublicHostedZone(this, "HostedZone", {
+    this.publicZone = new aws_route53.PublicHostedZone(this, "HostedZone", {
       zoneName: "rekisteridata.fi",
     })
     if (props.crossAccountId) {
@@ -17,7 +17,7 @@ export class DomainStack extends cdk.Stack {
         roleName: "Route53CrossDelegateRole"
       })
 
-      publicZone.grantDelegation(role)
+      this.publicZone.grantDelegation(role)
     }
   }
 }

--- a/cdk/lib/sub-domain-stack.ts
+++ b/cdk/lib/sub-domain-stack.ts
@@ -3,10 +3,11 @@ import {Construct} from "constructs";
 import {SubDomainStackProps} from "./sub-domain-stack-props";
 
 export class SubDomainStack extends Stack {
+    readonly subZone: aws_route53.PublicHostedZone;
     constructor(scope: Construct, id: string, props: SubDomainStackProps) {
         super(scope, id, props);
 
-        const subZone = new aws_route53.PublicHostedZone(this, 'SubZone', {
+        this.subZone = new aws_route53.PublicHostedZone(this, 'SubZone', {
             zoneName: props.subDomainName + ".rekisteridata.fi"
         })
 
@@ -21,13 +22,13 @@ export class SubDomainStack extends Stack {
         const delegationRole = aws_iam.Role.fromRoleArn(this, 'delegationRole', delegationRoleArn)
 
         new aws_route53.CrossAccountZoneDelegationRecord(this, 'delegate', {
-            delegatedZone: subZone,
+            delegatedZone: this.subZone,
             delegationRole: delegationRole,
             parentHostedZoneName: "rekisteridata.fi"
         })
 
         const rootRecord = new aws_route53.ARecord(this, 'subDomainRecord', {
-            zone: subZone,
+            zone: this.subZone,
             target: aws_route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(props.loadBalancer))
         })
 


### PR DESCRIPTION
In prod certificates are create using the root public zone, in dev sub public zone is used instead.