### PR TITLE
REKDAT-31: add ecs cluster and nginx container

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
+import * as dotenv from 'dotenv';
 import * as cdk from 'aws-cdk-lib';
 import { DomainStack } from '../lib/domain-stack';
 import {VpcStack} from "../lib/vpc-stack";
@@ -10,81 +11,113 @@ import {LoadBalancerStack} from "../lib/load-balancer-stack";
 import {SubDomainStack} from "../lib/sub-domain-stack";
 import {BackupStack} from "../lib/backup-stack";
 import {CertificateStack} from "../lib/certificate-stack";
+import {EnvProps, parseEnv} from "../lib/env-props";
+import {EcsClusterStack} from "../lib/ecs-cluster-stack";
+import {NginxStack} from "../lib/nginx-stack";
 
 const app = new cdk.App();
 
 const prodStackProps = {
-    account: '157248445006',
-    region: 'eu-north-1'
+  account: '157248445006',
+  region: 'eu-north-1',
+  environment: "prod"
 }
 
 const devStackProps = {
-    account: '332833619545',
-    region: 'eu-north-1'
+  account: '332833619545',
+  region: 'eu-north-1',
+  environment: "dev",
+  domainName: "dev.rekisteridata.fi",
+  secondaryDomainName: "dev.suojattudata.suomi.fi",
+  fqdn: "rekisteridata.fi",
+  secondaryFqdn: "suomi.fi"
 }
+
+
+// load .env file, shared with docker setup
+// mainly for ECR repo and image tag information
+dotenv.config({
+  path: '../docker/.env',
+});
+
+
+const envProps: EnvProps = {
+  // docker
+  REGISTRY: parseEnv('REGISTRY'),
+  REPOSITORY: parseEnv('REPOSITORY'),
+  // opendata images
+  CKAN_IMAGE_TAG: parseEnv('CKAN_IMAGE_TAG'),
+  SOLR_IMAGE_TAG: parseEnv('SOLR_IMAGE_TAG'),
+  NGINX_IMAGE_TAG: parseEnv('NGINX_IMAGE_TAG'),
+  // 3rd party image
+};
 
 // Common
 
 const DomainStackProd = new DomainStack(app, 'DomainStack-prod', {
-    env: {
-        account: prodStackProps.account,
-        region: prodStackProps.region
-    },
-    crossAccountId: devStackProps.account
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region
+  },
+  crossAccountId: devStackProps.account
 });
 
 // Dev
 
 const VpcStackDev = new VpcStack(app, 'VpcStack-dev', {
-    env: {
-        account: devStackProps.account,
-        region: devStackProps.region
-    }
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region
+  }
 })
 
 
 
 const KmsKeyStackDev = new KmsKeyStack(app, 'KmsKeyStack-dev', {
-    env: {
-        account: devStackProps.account,
-        region: devStackProps.region
-    },
-    environment: "dev",
-    vpc: VpcStackDev.vpc,
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region
+  },
+  envProps: envProps,
+  environment: devStackProps.environment,
+  vpc: VpcStackDev.vpc,
 })
 
 const BackupStackDev = new BackupStack(app, 'BackupStack-dev', {
-    env: {
-        account: devStackProps.account,
-        region: devStackProps.region,
-    },
-    vpc: VpcStackDev.vpc,
-    environment: "dev",
-    importVault: false,
-    backups: true
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  envProps: envProps,
+  vpc: VpcStackDev.vpc,
+  environment: devStackProps.environment,
+  importVault: false,
+  backups: true
 })
 
 const DatabaseStackDev = new DatabaseStack(app, 'DatabaseStack-dev', {
-    env: {
-        account: devStackProps.account,
-        region: devStackProps.region
-    },
-    environment: "dev",
-    vpc: VpcStackDev.vpc,
-    multiAz: false,
-    backups: true,
-    backupPlan: BackupStackDev.backupPlan,
-    cacheNodeType: 'cache.t3.micro',
-    numCacheNodes: 1
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region
+  },
+  envProps: envProps,
+  environment: devStackProps.environment,
+  vpc: VpcStackDev.vpc,
+  multiAz: false,
+  backups: true,
+  backupPlan: BackupStackDev.backupPlan,
+  cacheNodeType: 'cache.t3.micro',
+  numCacheNodes: 1
 })
 
 const LoadBalancerStackDev = new LoadBalancerStack(app, 'LoadBalancerStack-dev', {
-    env: {
-        account: devStackProps.account,
-        region: devStackProps.region
-    },
-    environment: "dev",
-    vpc: VpcStackDev.vpc
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region
+  },
+  envProps: envProps,
+  environment: devStackProps.environment,
+  vpc: VpcStackDev.vpc
 })
 
 const LambdaStackDev = new LambdaStack(app, 'LambdaStack-dev', {
@@ -92,82 +125,122 @@ const LambdaStackDev = new LambdaStack(app, 'LambdaStack-dev', {
     account: devStackProps.account,
     region: devStackProps.region,
   },
-  environment: "dev",
+  envProps: envProps,
+  environment: devStackProps.environment,
   ckanInstance: DatabaseStackDev.ckanInstance,
   ckanAdminCredentials: DatabaseStackDev.ckanAdminCredentials,
   vpc: VpcStackDev.vpc,
 })
 
 const SubDomainStackDev = new SubDomainStack(app, 'SubDomainStack-dev', {
-    env: {
-        account: devStackProps.account,
-        region: devStackProps.region,
-    },
-    prodAccountId: prodStackProps.account,
-    loadBalancer: LoadBalancerStackDev.loadBalancer,
-    subDomainName: "dev"
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  prodAccountId: prodStackProps.account,
+  subDomainName: "dev"
 })
 
 const CertificateStackDev = new CertificateStack(app, 'CertificateStack-dev', {
-    env: {
-        account: devStackProps.account,
-        region: devStackProps.region,
-    },
-    zone: SubDomainStackDev.subZone
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  zone: SubDomainStackDev.subZone
 })
 
+const EcsClusterStackDev = new EcsClusterStack(app, 'EcsClusterStack-dev', {
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  envProps: envProps,
+  environment: devStackProps.environment,
+  vpc: VpcStackDev.vpc
+})
+
+const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  envProps: envProps,
+  environment: devStackProps.environment,
+  vpc: VpcStackDev.vpc,
+  allowRobots: "false",
+  certificate: CertificateStackDev.certificate,
+  cluster: EcsClusterStackDev.cluster,
+  namespace: EcsClusterStackDev.namespace,
+  domainName: devStackProps.domainName,
+  fqdn: devStackProps.fqdn,
+  secondaryDomainName: devStackProps.secondaryDomainName,
+  secondaryFqdn: devStackProps.secondaryFqdn,
+  loadBalancer: LoadBalancerStackDev.loadBalancer,
+  zone: SubDomainStackDev.subZone,
+  taskDef: {
+    taskCpu: 512,
+    taskMem: 512,
+    taskMinCapacity: 1,
+    taskMaxCapacity: 1
+  }
+
+})
 
 // Production
 
 
 const VpcStackProd = new VpcStack(app, 'VpcStack-prod', {
-    env: {
-        account: prodStackProps.account,
-        region: prodStackProps.region
-    }
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region
+  }
 })
 
 const KmsKeyStackProd = new KmsKeyStack(app, 'KmsKeyStack-prod', {
-    env: {
-        account: prodStackProps.account,
-        region: prodStackProps.region
-    },
-    environment: "prod",
-    vpc: VpcStackProd.vpc,
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region
+  },
+  envProps: envProps,
+  environment: prodStackProps.environment,
+  vpc: VpcStackProd.vpc,
 })
 
 const BackupStackProd = new BackupStack(app, 'BackupStack-prod', {
-    env: {
-        account: prodStackProps.account,
-        region: prodStackProps.region,
-    },
-    vpc: VpcStackProd.vpc,
-    environment: "prod",
-    importVault: false,
-    backups: true
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region,
+  },
+  envProps: envProps,
+  vpc: VpcStackProd.vpc,
+  environment: prodStackProps.environment,
+  importVault: false,
+  backups: true
 })
 
 const DatabaseStackProd = new DatabaseStack(app, 'DatabaseStack-prod', {
-    env: {
-        account: prodStackProps.account,
-        region: prodStackProps.region
-    },
-    environment: "prod",
-    vpc: VpcStackProd.vpc,
-    multiAz: false,
-    backups: true,
-    backupPlan: BackupStackProd.backupPlan,
-    cacheNodeType: 'cache.t3.micro',
-    numCacheNodes: 1
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region
+  },
+  envProps: envProps,
+  environment: prodStackProps.environment,
+  vpc: VpcStackProd.vpc,
+  multiAz: false,
+  backups: true,
+  backupPlan: BackupStackProd.backupPlan,
+  cacheNodeType: 'cache.t3.micro',
+  numCacheNodes: 1
 })
 
 const LoadBalancerStackProd = new LoadBalancerStack(app, 'LoadBalancerStack-prod', {
-    env: {
-        account: prodStackProps.account,
-        region: prodStackProps.region
-    },
-    environment: "prod",
-    vpc: VpcStackProd.vpc
+  env: {
+    account: prodStackProps.account,
+    region: prodStackProps.region
+  },
+  envProps: envProps,
+  environment: prodStackProps.environment,
+  vpc: VpcStackProd.vpc
 })
 
 const LambdaStackProd = new LambdaStack(app, 'LambdaStack-prod', {
@@ -175,7 +248,8 @@ const LambdaStackProd = new LambdaStack(app, 'LambdaStack-prod', {
     account: prodStackProps.account,
     region: prodStackProps.region,
   },
-  environment: "prod",
+  envProps: envProps,
+  environment: prodStackProps.environment,
   ckanInstance: DatabaseStackProd.ckanInstance,
   ckanAdminCredentials: DatabaseStackProd.ckanAdminCredentials,
   vpc: VpcStackProd.vpc,

--- a/cdk/lib/common-stack-props.ts
+++ b/cdk/lib/common-stack-props.ts
@@ -1,7 +1,9 @@
 import {StackProps} from "aws-cdk-lib";
 import {IVpc} from "aws-cdk-lib/aws-ec2";
+import {EnvProps} from "./env-props";
 
 export interface CommonStackProps extends StackProps {
-    environment: string;
-    vpc: IVpc;
+  envProps: EnvProps;
+  environment: string;
+  vpc: IVpc;
 }

--- a/cdk/lib/ecs-cluster-stack-props.ts
+++ b/cdk/lib/ecs-cluster-stack-props.ts
@@ -1,0 +1,3 @@
+import {StackProps} from "aws-cdk-lib";
+
+export interface EcsClusterStackProps extends StackProps {}

--- a/cdk/lib/ecs-cluster-stack.ts
+++ b/cdk/lib/ecs-cluster-stack.ts
@@ -1,0 +1,16 @@
+import {aws_ecs, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import {CommonStackProps} from "./common-stack-props";
+
+export class EcsClusterStack extends Stack {
+  readonly cluster: aws_ecs.ICluster;
+  constructor(scope: Construct, id: string, props: CommonStackProps) {
+    super(scope, id, props);
+
+    this.cluster = new aws_ecs.Cluster(this, 'ECSCluster', {
+      vpc: props.vpc,
+      enableFargateCapacityProviders: true
+    })
+
+  }
+}

--- a/cdk/lib/ecs-cluster-stack.ts
+++ b/cdk/lib/ecs-cluster-stack.ts
@@ -1,9 +1,10 @@
-import {aws_ecs, Stack} from "aws-cdk-lib";
+import {aws_ecs, aws_servicediscovery, Stack} from "aws-cdk-lib";
 import {Construct} from "constructs";
 import {CommonStackProps} from "./common-stack-props";
 
 export class EcsClusterStack extends Stack {
   readonly cluster: aws_ecs.ICluster;
+  readonly namespace: aws_servicediscovery.INamespace;
   constructor(scope: Construct, id: string, props: CommonStackProps) {
     super(scope, id, props);
 
@@ -11,6 +12,11 @@ export class EcsClusterStack extends Stack {
       vpc: props.vpc,
       enableFargateCapacityProviders: true
     })
+
+    this.namespace = new aws_servicediscovery.PrivateDnsNamespace(this, 'namespace', {
+      name: `${props.environment}-opendata-ns`,
+      vpc: props.vpc,
+    });
 
   }
 }

--- a/cdk/lib/ecs-stack-props.ts
+++ b/cdk/lib/ecs-stack-props.ts
@@ -1,0 +1,6 @@
+import {CommonStackProps} from "./common-stack-props";
+import {EcsTaskDefinitionProps} from "./ecs-task-definition-props";
+
+export interface EcsStackProps extends CommonStackProps {
+  taskDef: EcsTaskDefinitionProps
+}

--- a/cdk/lib/ecs-stack-props.ts
+++ b/cdk/lib/ecs-stack-props.ts
@@ -1,6 +1,13 @@
 import {CommonStackProps} from "./common-stack-props";
 import {EcsTaskDefinitionProps} from "./ecs-task-definition-props";
+import {aws_ecs, aws_servicediscovery} from "aws-cdk-lib";
 
 export interface EcsStackProps extends CommonStackProps {
-  taskDef: EcsTaskDefinitionProps
+  taskDef: EcsTaskDefinitionProps,
+  domainName: string,
+  secondaryDomainName: string,
+  fqdn: string,
+  secondaryFqdn: string,
+  namespace: aws_servicediscovery.INamespace,
+  cluster: aws_ecs.ICluster
 }

--- a/cdk/lib/ecs-task-definition-props.ts
+++ b/cdk/lib/ecs-task-definition-props.ts
@@ -1,0 +1,28 @@
+export interface EcsTaskDefinitionProps {
+  /**
+   * The number of cpu units used by the task.
+   * 256 (0.25 vCPU), 512 (0.5 vCPU), 1024 (1.0 vCPU), 2048 (2.0 vCPU), 4096 (4.0 vCPU)
+   */
+  taskCpu: number;
+  /**
+   * The amount (in MiB) of memory used by the task.
+   * 0.25 vCPU: 512MB, 1024MB, 2048MB
+   * 0.5  vCPU: 1024MB, 2048MB, 3072MB, 4096MB
+   * 1.0  vCPU: 2048MB, 3072MB, 4096MB, 5120MB, 6144MB, 7168MB, 8192MB
+   * 2.0  vCPU: 4096MB, 16384MB in increments of 1024MB
+   * 4.0  vCPU: 8192MB, 30720MB in increments of 1024MB
+   */
+  taskMem: number;
+  /**
+   * Minimum number of tasks at a time.
+   */
+  taskMinCapacity: number;
+  /**
+   * Maximum number of tasks at a time.
+   */
+  taskMaxCapacity: number;
+  /**
+   * The amount (in GiB) of ephemeral storage to be allocated to the task.
+   */
+  taskStorage?: number;
+}

--- a/cdk/lib/env-props.ts
+++ b/cdk/lib/env-props.ts
@@ -1,0 +1,28 @@
+import {Stack} from "aws-cdk-lib";
+
+export interface EnvProps {
+  REGISTRY: string;
+  REPOSITORY: string;
+  NGINX_IMAGE_TAG: string;
+  SOLR_IMAGE_TAG: string;
+  CKAN_IMAGE_TAG: string;
+}
+
+export function getRepositoryArn(stack: Stack, registryURI: string, repository: string) {
+
+  const parsedRepository = registryURI.match(/(\d{12})\.dkr\.ecr.(.*)\.amazonaws\.com/)
+
+  if (parsedRepository) {
+    const account = parsedRepository[0]
+    const region = parsedRepository[1]
+    return Stack.of(stack).formatArn({
+      account: account,
+      region: region,
+      resource: "repository",
+      service: "ecr",
+      resourceName: repository
+    })
+  }
+
+  return ""
+}

--- a/cdk/lib/env-props.ts
+++ b/cdk/lib/env-props.ts
@@ -8,9 +8,9 @@ export interface EnvProps {
   CKAN_IMAGE_TAG: string;
 }
 
-export function getRepositoryArn(stack: Stack, registryURI: string, repository: string) {
+export function getRepositoryArn(stack: Stack, repositoryURI: string, registry: string) {
 
-  const parsedRepository = registryURI.match(/(\d{12})\.dkr\.ecr.(.*)\.amazonaws\.com/)
+  const parsedRepository = repositoryURI.match(/(\d{12})\.dkr\.ecr.(.*)\.amazonaws\.com/)
 
   if (parsedRepository) {
     const account = parsedRepository[0]
@@ -20,9 +20,18 @@ export function getRepositoryArn(stack: Stack, registryURI: string, repository: 
       region: region,
       resource: "repository",
       service: "ecr",
-      resourceName: repository
+      resourceName: registry
     })
   }
 
   return ""
+}
+
+
+export function parseEnv(key: string): string {
+  let val = process.env[key];
+  if (val == null) {
+    throw new Error(`parseEnv error: ${key} is undefined or null!`);
+  }
+  return val;
 }

--- a/cdk/lib/env-props.ts
+++ b/cdk/lib/env-props.ts
@@ -12,19 +12,20 @@ export function getRepositoryArn(stack: Stack, repositoryURI: string, registry: 
 
   const parsedRepository = repositoryURI.match(/(\d{12})\.dkr\.ecr.(.*)\.amazonaws\.com/)
 
-  if (parsedRepository) {
-    const account = parsedRepository[0]
-    const region = parsedRepository[1]
-    return Stack.of(stack).formatArn({
-      account: account,
-      region: region,
-      resource: "repository",
-      service: "ecr",
-      resourceName: registry
-    })
+  if (parsedRepository === null) {
+    throw new Error(`Invalid repository URI: ${repositoryURI} is not valid`)
   }
 
-  return ""
+  const account = parsedRepository[0]
+  const region = parsedRepository[1]
+  return Stack.of(stack).formatArn({
+    account: account,
+    region: region,
+    resource: "repository",
+    service: "ecr",
+    resourceName: registry
+  })
+
 }
 
 

--- a/cdk/lib/lambda-stack.ts
+++ b/cdk/lib/lambda-stack.ts
@@ -17,6 +17,7 @@ export class LambdaStack extends Stack {
 
     const createDatabases = new CreateDatabasesAndUsers(this, 'create-databases-and-users', {
       env: props.env,
+      envProps: props.envProps,
       ckanInstance: props.ckanInstance,
       ckanAdminCredentials: props.ckanAdminCredentials,
       vpc: props.vpc,

--- a/cdk/lib/nginx-stack-props.ts
+++ b/cdk/lib/nginx-stack-props.ts
@@ -1,0 +1,9 @@
+import {EcsStackProps} from "./ecs-stack-props";
+import {aws_certificatemanager, aws_elasticloadbalancingv2, aws_route53} from "aws-cdk-lib";
+
+export interface NginxStackProps extends EcsStackProps {
+  allowRobots: string,
+  certificate: aws_certificatemanager.ICertificate,
+  loadBalancer: aws_elasticloadbalancingv2.IApplicationLoadBalancer,
+  zone: aws_route53.IPublicHostedZone
+}

--- a/cdk/lib/nginx-stack.ts
+++ b/cdk/lib/nginx-stack.ts
@@ -1,0 +1,71 @@
+import {aws_ecr, aws_ecs, aws_logs, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import {CommonStackProps} from "./common-stack-props";
+import {EcsStackProps} from "./ecs-stack-props";
+import {getRepositoryArn} from "./env-props";
+
+
+export class NginxStack extends Stack {
+
+  constructor(scope: Construct, id: string, props: EcsStackProps) {
+    super(scope, id, props);
+
+    const nginxLogGroup = new aws_logs.LogGroup(this, 'nginxLogGroup', {
+      logGroupName: `/${props.environment}/registrydata/nginx`,
+    });
+
+    const nginxRepo = aws_ecr.Repository.fromRepositoryArn(this, 'nginxRepo',
+      getRepositoryArn(this, props.envProps.REGISTRY, props.envProps.REPOSITORY + '/nginx'));
+
+
+    const nginxTaskDefinition = new aws_ecs.FargateTaskDefinition(this, "nginxTaskDef", {
+      cpu: props.taskDef.taskCpu,
+      memoryLimitMiB: props.taskDef.taskMem
+    })
+
+    // define nginx content security policies
+    const nginxCspDefaultSrc: string[] = [];
+    const nginxCspScriptSrc: string[] = [];
+    const nginxCspStyleSrc: string[] = [];
+    const nginxCspFrameSrc: string[] = [];
+
+
+    const nginxContainer = nginxTaskDefinition.addContainer('nginx', {
+      image: aws_ecs.ContainerImage.fromEcrRepository(nginxRepo, props.envProps.NGINX_IMAGE_TAG),
+      environment: {
+        // .env.nginx
+        NGINX_ROOT: '/var/www/html',
+        NGINX_MAX_BODY_SIZE: '5000M',
+        NGINX_EXPIRES: '1h',
+        NGINX_CSP_DEFAULT_SRC: nginxCspDefaultSrc.join(' '),
+        NGINX_CSP_SCRIPT_SRC: nginxCspScriptSrc.join(' '),
+        NGINX_CSP_STYLE_SRC: nginxCspStyleSrc.join(' '),
+        NGINX_CSP_FRAME_SRC: nginxCspFrameSrc.join(' '),
+
+        // .env
+        NGINX_PORT: "80",
+        DOMAIN_NAME: props.domainName,
+        SECONDARY_DOMAIN_NAME: props.secondaryDomainName,
+        BASE_DOMAIN_NAME: props.fqdn,
+        SECONDARY_BASE_DOMAIN_NAME: props.secondaryFqdn,
+        NAMESERVER: pNameserver.stringValue,
+        CKAN_HOST: `ckan.${props.namespace.namespaceName}`,
+        CKAN_PORT: '5000',
+        NGINX_ROBOTS_ALLOW: props.allowRobots,
+      },
+      logging: aws_ecs.LogDrivers.awsLogs({
+        logGroup: nginxLogGroup,
+        streamPrefix: 'nginx-service'
+      })
+    })
+
+    nginxContainer.addPortMappings({
+      containerPort: 80,
+      protocol: aws_ecs.Protocol.TCP,
+    });
+
+
+
+  }
+}
+

--- a/cdk/lib/sub-domain-stack-props.ts
+++ b/cdk/lib/sub-domain-stack-props.ts
@@ -4,5 +4,4 @@ import {ApplicationLoadBalancer} from "aws-cdk-lib/aws-elasticloadbalancingv2";
 export interface SubDomainStackProps extends StackProps {
     prodAccountId: string;
     subDomainName: string;
-    loadBalancer: ApplicationLoadBalancer;
 }

--- a/cdk/lib/sub-domain-stack.ts
+++ b/cdk/lib/sub-domain-stack.ts
@@ -27,10 +27,7 @@ export class SubDomainStack extends Stack {
             parentHostedZoneName: "rekisteridata.fi"
         })
 
-        const rootRecord = new aws_route53.ARecord(this, 'subDomainRecord', {
-            zone: this.subZone,
-            target: aws_route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(props.loadBalancer))
-        })
+
 
     }
 

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-secrets-manager": "^3.370.0",
         "aws-cdk-lib": "2.92.0",
         "constructs": "^10.0.0",
+        "dotenv": "^16.3.1",
         "knex": "^2.4.2",
         "pg": "^8.11.0",
         "source-map-support": "^0.5.21"
@@ -3134,6 +3135,17 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8019,6 +8031,11 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.499",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -14,18 +14,19 @@
     "@types/aws-lambda": "^8.10.117",
     "@types/jest": "^29.5.3",
     "@types/node": "20.4.10",
+    "aws-cdk": "2.92.0",
     "jest": "^29.6.2",
     "ts-jest": "^29.1.1",
-    "aws-cdk": "2.92.0",
     "ts-node": "^10.9.1",
     "typescript": "~5.1.6"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.92.0",
     "@aws-sdk/client-secrets-manager": "^3.370.0",
+    "aws-cdk-lib": "2.92.0",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.21",
+    "dotenv": "^16.3.1",
     "knex": "^2.4.2",
-    "pg": "^8.11.0"
+    "pg": "^8.11.0",
+    "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
Various configurations to get nginx container running, still referencing old domain as the new domain hasn't been registered. Configuring A record to loadbalancer is moved to nginx stack to avoid cyclic reference.