### PR TITLE
REKDAT-31: Add solr stack

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -14,6 +14,8 @@ import {CertificateStack} from "../lib/certificate-stack";
 import {EnvProps, parseEnv} from "../lib/env-props";
 import {EcsClusterStack} from "../lib/ecs-cluster-stack";
 import {NginxStack} from "../lib/nginx-stack";
+import {SolrStack} from "../lib/solr-stack";
+import {FileSystemStack} from "../lib/filesystem-stack";
 
 const app = new cdk.App();
 
@@ -159,6 +161,17 @@ const EcsClusterStackDev = new EcsClusterStack(app, 'EcsClusterStack-dev', {
   vpc: VpcStackDev.vpc
 })
 
+const FileSystemStackDev = new FileSystemStack(app, 'FilesystemStack-dev', {
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  envProps: envProps,
+  environment: devStackProps.environment,
+  vpc: VpcStackDev.vpc
+})
+
+
 const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
   env: {
     account: devStackProps.account,
@@ -185,6 +198,26 @@ const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
   }
 
 })
+
+const SolrStackDev = new SolrStack(app, 'SolrStack-dev', {
+  env: {
+    account: devStackProps.account,
+    region: devStackProps.region,
+  },
+  envProps: envProps,
+  environment: devStackProps.environment,
+  cluster: EcsClusterStackDev.cluster,
+  namespace: EcsClusterStackDev.namespace,
+  taskDef: {
+    taskCpu: 256,
+    taskMem: 512,
+    taskMinCapacity: 1,
+    taskMaxCapacity: 1
+  },
+  vpc: VpcStackDev.vpc,
+  fileSystem: FileSystemStackDev.solrFs
+})
+
 
 // Production
 

--- a/cdk/lib/ecs-stack-props.ts
+++ b/cdk/lib/ecs-stack-props.ts
@@ -1,13 +1,10 @@
 import {CommonStackProps} from "./common-stack-props";
 import {EcsTaskDefinitionProps} from "./ecs-task-definition-props";
-import {aws_ecs, aws_servicediscovery} from "aws-cdk-lib";
+import {aws_ecs, aws_efs, aws_servicediscovery} from "aws-cdk-lib";
 
 export interface EcsStackProps extends CommonStackProps {
   taskDef: EcsTaskDefinitionProps,
-  domainName: string,
-  secondaryDomainName: string,
-  fqdn: string,
-  secondaryFqdn: string,
   namespace: aws_servicediscovery.INamespace,
-  cluster: aws_ecs.ICluster
+  cluster: aws_ecs.ICluster,
+  fileSystem?: aws_efs.FileSystem
 }

--- a/cdk/lib/efs-stack-props.ts
+++ b/cdk/lib/efs-stack-props.ts
@@ -1,0 +1,8 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+
+import { CommonStackProps } from './common-stack-props';
+import {aws_backup} from "aws-cdk-lib";
+
+export interface EfsStackProps extends CommonStackProps {
+  vpc: ec2.IVpc;
+}

--- a/cdk/lib/filesystem-stack.ts
+++ b/cdk/lib/filesystem-stack.ts
@@ -1,0 +1,26 @@
+import { Stack } from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as efs from 'aws-cdk-lib/aws-efs';
+
+import { Construct } from 'constructs';
+
+import { EfsStackProps } from './efs-stack-props';
+
+export class FileSystemStack extends Stack {
+  readonly solrFs: efs.FileSystem;
+
+  constructor(scope: Construct, id: string, props: EfsStackProps) {
+    super(scope, id, props);
+
+    this.solrFs = new efs.FileSystem(this, 'solrFs', {
+      vpc: props.vpc,
+      performanceMode: efs.PerformanceMode.GENERAL_PURPOSE,
+      throughputMode: efs.ThroughputMode.BURSTING,
+      vpcSubnets: {
+        subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+      },
+      encrypted: true,
+    });
+
+  }
+}

--- a/cdk/lib/nginx-stack-props.ts
+++ b/cdk/lib/nginx-stack-props.ts
@@ -5,5 +5,10 @@ export interface NginxStackProps extends EcsStackProps {
   allowRobots: string,
   certificate: aws_certificatemanager.ICertificate,
   loadBalancer: aws_elasticloadbalancingv2.IApplicationLoadBalancer,
-  zone: aws_route53.IPublicHostedZone
+  zone: aws_route53.IPublicHostedZone,
+  domainName: string,
+  secondaryDomainName: string,
+  fqdn: string,
+  secondaryFqdn: string,
+
 }

--- a/cdk/lib/solr-stack.ts
+++ b/cdk/lib/solr-stack.ts
@@ -1,0 +1,109 @@
+import {aws_ec2, aws_ecr, aws_ecs, aws_logs, Duration, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import * as sd from 'aws-cdk-lib/aws-servicediscovery';
+import * as efs from 'aws-cdk-lib/aws-efs';
+import {EcsStackProps} from "./ecs-stack-props";
+import {getRepositoryArn} from "./env-props";
+
+export class SolrStack extends Stack {
+  constructor(scope: Construct, id: string, props: EcsStackProps) {
+    super(scope, id, props);
+
+    const solrLogGroup = new aws_logs.LogGroup(this, 'solrLogGroup', {
+      logGroupName: `/${props.environment}/registrydata/solr`,
+    });
+
+    const solrRepo = aws_ecr.Repository.fromRepositoryArn(this, 'solrRepo',
+      getRepositoryArn(this, props.envProps.REGISTRY, props.envProps.REPOSITORY + '/solr'));
+
+
+    const solrFsDataAccessPoint = props.fileSystem!.addAccessPoint('solrFsDataAccessPoint', {
+      path: '/solr_data',
+      createAcl: {
+        ownerGid: '8983',
+        ownerUid: '8983',
+        permissions: '0755',
+      },
+      posixUser: {
+        gid: '8983',
+        uid: '8983',
+      },
+    });
+
+    const solrTaskDef = new aws_ecs.FargateTaskDefinition(this, 'solrTaskDef', {
+      cpu: props.taskDef.taskCpu,
+      memoryLimitMiB: props.taskDef.taskMem,
+      volumes: [
+        {
+          name: 'solr_data',
+          efsVolumeConfiguration: {
+            fileSystemId: props.fileSystem!.fileSystemId,
+            authorizationConfig: {
+              accessPointId: solrFsDataAccessPoint.accessPointId,
+            },
+            transitEncryption: 'ENABLED',
+          },
+        }
+      ],
+    });
+
+
+    const solrContainer = solrTaskDef.addContainer('solr', {
+      image: aws_ecs.ContainerImage.fromEcrRepository(solrRepo, props.envProps.SOLR_IMAGE_TAG),
+      logging: aws_ecs.LogDrivers.awsLogs({
+        logGroup: solrLogGroup,
+        streamPrefix: 'solr-service',
+      }),
+      healthCheck: {
+        command: ['CMD-SHELL', 'curl --fail -s http://localhost:8983/solr/ckan/admin/ping?wt=json | grep -o "OK"'],
+        interval: Duration.seconds(15),
+        timeout: Duration.seconds(5),
+        retries: 5,
+        startPeriod: Duration.seconds(15),
+      },
+    });
+
+    solrContainer.addPortMappings({
+      containerPort: 8983,
+      protocol: aws_ecs.Protocol.TCP,
+    });
+
+    solrContainer.addMountPoints({
+      containerPath: '/opt/solr/server/solr/ckan/data',
+      readOnly: false,
+      sourceVolume: 'solr_data',
+    });
+
+    const solrService = new aws_ecs.FargateService(this, 'solrService', {
+      platformVersion: aws_ecs.FargatePlatformVersion.VERSION1_4,
+      cluster: props.cluster,
+      taskDefinition: solrTaskDef,
+      desiredCount: 1,
+      minHealthyPercent: 0,
+      maxHealthyPercent: 100,
+      cloudMapOptions: {
+        cloudMapNamespace: props.namespace,
+        dnsRecordType: sd.DnsRecordType.A,
+        dnsTtl: Duration.minutes(1),
+        name: 'solr',
+        container: solrContainer,
+        containerPort: 8983
+      },
+    });
+
+    if (props.fileSystem){
+      // not sure if needed
+      //solrService.connections.allowFrom(props.fileSystem, aws_ec2.Port.tcp(2049), 'EFS connection (solr)');
+      solrService.connections.allowTo(props.fileSystem, aws_ec2.Port.tcp(2049), 'EFS connection (solr)');
+    }
+
+
+    const solrServiceAsg = solrService.autoScaleTaskCount({
+      minCapacity: props.taskDef.taskMinCapacity,
+      maxCapacity: props.taskDef.taskMaxCapacity,
+    });
+
+
+
+  }
+}

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,6 +1,6 @@
 FROM solr:9.0.0
 
-# switch from solr to root user
+# switch from solr to root user 
 USER root
 
 # upgrade system


### PR DESCRIPTION
Adds solr and efs stacks, efs volume is required by solr as the volume is essential to store long term data. Moves some of the properties around for not having to copy paste not needed properties to all stacks.