### PR TITLE
Move infrastructure to use new domain

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -30,9 +30,9 @@ const devStackProps = {
   account: '332833619545',
   region: 'eu-north-1',
   environment: "dev",
-  domainName: "dev.rekisteridata.fi",
+  domainName: "dev.suojattudata.fi",
   secondaryDomainName: "dev.suojattudata.suomi.fi",
-  fqdn: "rekisteridata.fi",
+  fqdn: "suojattudata.fi",
   secondaryFqdn: "suomi.fi"
 }
 
@@ -183,7 +183,7 @@ const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
   environment: devStackProps.environment,
   vpc: VpcStackDev.vpc,
   allowRobots: "false",
-  certificate: CertificateStackDev.certificate,
+  certificate: CertificateStackDev.newCertificate,
   cluster: EcsClusterStackDev.cluster,
   namespace: EcsClusterStackDev.namespace,
   domainName: devStackProps.domainName,


### PR DESCRIPTION
Might require destroying current stacks due to references but we will see once this is deployed.