### PR TITLE
REKDAT-45: Move sysadmin secret to database stack and encrypt database

### DIFF
--- a/cdk/lib/ckan-stack-props.ts
+++ b/cdk/lib/ckan-stack-props.ts
@@ -1,6 +1,6 @@
 import {EcsStackProps} from "./ecs-stack-props";
 import {CfnCacheCluster} from "aws-cdk-lib/aws-elasticache";
-import {aws_ec2, aws_ecs, aws_ecs_patterns, aws_rds} from "aws-cdk-lib";
+import {aws_ec2, aws_ecs, aws_ecs_patterns, aws_rds, aws_secretsmanager} from "aws-cdk-lib";
 
 export interface CkanStackProps extends EcsStackProps {
   domainName: string,
@@ -9,6 +9,7 @@ export interface CkanStackProps extends EcsStackProps {
   redisSecurityGroup: aws_ec2.ISecurityGroup,
   ckanInstance: aws_rds.IDatabaseInstance,
   ckanInstanceCredentials: aws_rds.Credentials
+  ckanSysAdminSecret: aws_secretsmanager.ISecret,
   databaseSecurityGroup: aws_ec2.ISecurityGroup,
   solrService: aws_ecs.FargateService,
   nginxService: aws_ecs_patterns.ApplicationLoadBalancedFargateService

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -111,12 +111,7 @@ export class CkanStack extends Stack {
       }
     })
 
-    const ckanSysAdminSecret = new aws_secretsmanager.Secret(this, 'ckanSysAdminSecret', {
-      encryptionKey: secretEncryptionKey,
-      generateSecretString: {
-        excludeCharacters: "%"
-      }
-    })
+
 
     const ckanContainerSecrets: { [key: string]: aws_ecs.Secret; } = {
       // .env.ckan
@@ -126,7 +121,7 @@ export class CkanStack extends Stack {
       DB_CKAN_PASS: aws_ecs.Secret.fromSecretsManager(props.ckanInstanceCredentials.secret!, 'password'),
       SMTP_USERNAME: aws_ecs.Secret.fromSecretsManager(smtpSecrets, 'username'),
       SMTP_PASS: aws_ecs.Secret.fromSecretsManager(smtpSecrets, 'password'),
-      CKAN_SYSADMIN_PASSWORD: aws_ecs.Secret.fromSecretsManager(ckanSysAdminSecret),
+      CKAN_SYSADMIN_PASSWORD: aws_ecs.Secret.fromSecretsManager(props.ckanSysAdminSecret),
     };
 
     ckanTaskDefinition.addToExecutionRolePolicy(new PolicyStatement({


### PR DESCRIPTION
Database was encrypted which then caused replacement of databases. Sysadmin secret now is bound to the database stack itself so it should not be replaced as often.