### PR TITLE
REKDAT-48: Replace rekisteridata.fi with suojattudata.suomi.fi

### DIFF
--- a/cdk/lib/certificate-stack.ts
+++ b/cdk/lib/certificate-stack.ts
@@ -8,10 +8,10 @@ export class CertificateStack extends Stack {
     constructor(scope: Construct, id: string, props: CertificateStackProps) {
         super(scope, id, props);
 
-        this.certificate = new acm.Certificate(this, 'Certificate', {
-            domainName: props.zone.zoneName,
-            validation: acm.CertificateValidation.fromDns(props.zone)
-        })
+        //this.certificate = new acm.Certificate(this, 'Certificate', {
+        //    domainName: props.zone.zoneName,
+        //    validation: acm.CertificateValidation.fromDns(props.zone)
+        //})
 
         this.newCertificate = new acm.Certificate(this, 'NewCertificate', {
           domainName: props.newZone.zoneName,

--- a/cdk/lib/domain-stack.ts
+++ b/cdk/lib/domain-stack.ts
@@ -10,7 +10,7 @@ export class DomainStack extends cdk.Stack {
     super(scope, id, props);
 
     this.publicZone = new aws_route53.PublicHostedZone(this, "HostedZone", {
-      zoneName: "rekisteridata.fi",
+      zoneName: "suojattudata.suomi.fi",
     })
 
     this.newPublicZone = new aws_route53.PublicHostedZone(this, "NewPublicHostedZone", {

--- a/cdk/lib/sub-domain-stack.ts
+++ b/cdk/lib/sub-domain-stack.ts
@@ -8,9 +8,9 @@ export class SubDomainStack extends Stack {
     constructor(scope: Construct, id: string, props: SubDomainStackProps) {
         super(scope, id, props);
 
-        this.subZone = new aws_route53.PublicHostedZone(this, 'SubZone', {
-            zoneName: props.subDomainName + ".rekisteridata.fi"
-        })
+        //this.subZone = new aws_route53.PublicHostedZone(this, 'SubZone', {
+        //    zoneName: props.subDomainName + ".suojattudata.suomi.fi"
+        //})
 
         this.newSubZone = new aws_route53.PublicHostedZone(this, 'NewSubZone', {
           zoneName: props.subDomainName + ".suojattudata.fi"
@@ -26,11 +26,11 @@ export class SubDomainStack extends Stack {
 
         const delegationRole = aws_iam.Role.fromRoleArn(this, 'delegationRole', delegationRoleArn)
 
-        new aws_route53.CrossAccountZoneDelegationRecord(this, 'delegate', {
-            delegatedZone: this.subZone,
-            delegationRole: delegationRole,
-            parentHostedZoneName: "rekisteridata.fi"
-        })
+        //new aws_route53.CrossAccountZoneDelegationRecord(this, 'delegate', {
+        //    delegatedZone: this.subZone,
+        //    delegationRole: delegationRole,
+        //    parentHostedZoneName: "suojattudata.suomi.fi"
+        //})
 
         new aws_route53.CrossAccountZoneDelegationRecord(this, 'newDelegate', {
           delegatedZone: this.newSubZone,

--- a/cdk/test/domain-stack.test.ts
+++ b/cdk/test/domain-stack.test.ts
@@ -10,6 +10,6 @@ test("Hosted zone created", () => {
     const template = Template.fromStack(stack);
 
     template.hasResourceProperties('AWS::Route53::HostedZone', {
-        Name: "rekisteridata.fi."
+        Name: "suojattudata.suomi.fi."
     })
 })


### PR DESCRIPTION
Subdomains and certificates are disabled as the domain needs to be registered first on a third party.