### PR TITLE
REKDAT-65: auth cookie has different name in ckan 2.10

### DIFF
--- a/docker/nginx/templates/site.conf.template
+++ b/docker/nginx/templates/site.conf.template
@@ -1,7 +1,6 @@
 # auth token mapping, prevents caching
 map $http_cookie $no_cache {
-  default $cookie_auth_tkt;
-  ~SESS 1;
+  default $cookie_ckan;
 }
 
 # http scheme mapping


### PR DESCRIPTION
Based of on @bzar findings, use correct cookie in cache bybass in nginx cache.