### PR TITLE
REKDAT-61: Fix dataset categories and activity page layouts

### DIFF
--- a/assets/src/scss/ckan/common.scss
+++ b/assets/src/scss/ckan/common.scss
@@ -58,6 +58,7 @@
     border: rd.$border-light;
     border-radius: 2px;
     padding: 20px 30px;
+    min-height: 100%; // Extend to match when shorter than sidebar
 
     .module-content {
       padding: 0;
@@ -317,5 +318,29 @@
   }
   td:last-child, th:last-child {
     padding-right: 20px;
+  }
+}
+
+.media-grid {
+  background: none;
+  padding: 0;
+  border: none;
+
+  .media-item {
+    min-width: 335px;
+    padding: 10px 20px;
+    margin: 20px 20px 0 0;
+    box-shadow: 0px 2px 4px 1px rgba(41, 41, 41, 0.20);
+    border: rd.$border-light;
+
+    .media-heading {
+      font-size: rd.$font-size-lg;
+      font-weight: rd.$font-weight-bold;
+    }
+    .media-image {
+      float: left;
+      width: 64px;
+      margin: 0 16px 32px 0; // Bottom margin to avoid text wrapping
+    }
   }
 }

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/package/read.html
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/package/read.html
@@ -2,15 +2,6 @@
 
 {% import 'macros/layout.html' as layout %}
 
-{% block content_header %}
-<header class="page-header">
-  <ul class="nav nav-tabs">
-    <li class="active">{% link_for _('Dataset'), named_route=dataset_type ~ '.read', id=pkg.name %}</li>
-    <li>{% link_for _('Categories'), named_route=dataset_type ~ '.groups', id=pkg.name %}</li>
-    <li>{% link_for _('Activity'), named_route=dataset_type ~ '.activity', id=pkg.name %}</li>
-</header>
-{% endblock %}
-
 {% block pre_primary %}
   {% snippet 'package/snippets/dataset_state_banner.html', pkg=pkg %}
 {% endblock pre_primary %}
@@ -21,8 +12,6 @@
        href="{{ h.url_for(dataset_type ~ '.edit', id=pkg.name) }}">{{ _('Edit ' + dataset_type) }}</a>
   {% endif %}
 {% endblock content_action %}
-
-{%- block primary_container_class -%}primary-content-container{%- endblock primary_container_class -%}
 
 {% block secondary_content %}
   {% block package_tags %}

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/package/read_base.html
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/package/read_base.html
@@ -1,0 +1,19 @@
+{% ckan_extends %}
+
+{% block content_header %}
+<header class="page-header">
+  <ul class="nav nav-tabs">
+    {{ h.build_nav(dataset_type ~ '.read', _('Dataset'), id=pkg.name)}}
+    {{ h.build_nav(dataset_type ~ '.groups', _('Categories'), id=pkg.name)}}
+    {{ h.build_nav('activity.package_activity', _('Activity'), id=pkg.name)}}
+    {#
+    <li class="active">{% link_for _('Dataset'), named_route=dataset_type ~ '.read', id=pkg.name %}</li>
+    <li>{% link_for _('Categories'), named_route=dataset_type ~ '.groups', id=pkg.name %}</li>
+    <li>{% link_for _('Activity'), named_route=dataset_type ~ '.activity', id=pkg.name %}</li>
+    #}
+</header>
+{% endblock %}
+
+{%- block primary_container_class -%}primary-content-container{%- endblock primary_container_class -%}
+
+


### PR DESCRIPTION
- Make dataset category/activities pages have navigation and layout like the main page
- Tune category grid to match design
![image](https://github.com/vrk-kpa/registrydata/assets/726461/b47711f1-83b1-4417-951f-db05506d52dd)
![image](https://github.com/vrk-kpa/registrydata/assets/726461/27cbe648-c253-42d0-b899-699e1ccfacb8)
