### PR TITLE
REKDAT-46: fix tagging images when assets change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Update .env.template to reference new ckan image
-        if: ${{ (needs.build-and-test-containers.outputs.ckan == 'true') }}
+        if: ${{ (needs.build-and-test-containers.outputs.ckan == 'true') || (needs.build-and-test-containers.outputs.assets == 'true') }}
         run: |
           sed -i.bak -E 's/^(CKAN_IMAGE_TAG[[:blank:]]*=[[:blank:]]*).*/\1\"'"${{ github.sha }}"'\"/' docker/.env.template
 
@@ -150,7 +150,8 @@ jobs:
         id: envtemplate
         if: ${{ (needs.build-and-test-containers.outputs.ckan == 'true') ||
           (needs.build-and-test-containers.outputs.solr == 'true') ||
-          (needs.build-and-test-containers.outputs.nginx == 'true') }}
+          (needs.build-and-test-containers.outputs.nginx == 'true') ||
+          (needs.build-and-test-containers.outputs.assets == 'true') }}
         run: |
           git config user.name "YTP Bot"
           git config user.email "yhteentoimivuus.kehittajat@gofore.com"

--- a/assets/src/scss/variables.scss
+++ b/assets/src/scss/variables.scss
@@ -5,7 +5,7 @@ $font-path: "../../../fonts";
 $image-path: "../../../images";
 $vendor-path: "../../../vendor";
 
-// Colors
+// Colors 
 $color-primary: tokens.$fi-color-highlight-light2; // #D5E4F6
 $color-secondary: tokens.$fi-color-depth-secondary-dark1; // #E5F0FF
 $color-link-text: tokens.$fi-color-highlight-base; // #2A6EBB


### PR DESCRIPTION
Changes to assets didn't commit new image to .env-template even though the image was pushed.