### PR TITLE
REKDAT-65: Add beaker.validate_key for trying to solve session issues

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -142,12 +142,19 @@ export class CkanStack extends Stack {
       }
     })
 
+    const beakerValidateKeySecret = new aws_secretsmanager.Secret(this, 'beakerValidateKey', {
+      encryptionKey: secretEncryptionKey,
+      generateSecretString: {
+        excludeCharacters: "%"
+      }
+    })
 
 
     const ckanContainerSecrets: { [key: string]: aws_ecs.Secret; } = {
       // .env.ckan
       CKAN_BEAKER_SESSION_SECRET: aws_ecs.Secret.fromSecretsManager(beakerSecret),
       CKAN_APP_INSTANCE_UUID: aws_ecs.Secret.fromSecretsManager(appUUIDSecret),
+      CKAN_BEAKER_SESSION_VALIDATE_KEY: aws_ecs.Secret.fromSecretsManager(beakerValidateKeySecret),
       // .env
       DB_CKAN_PASS: aws_ecs.Secret.fromSecretsManager(props.ckanInstanceCredentials.secret!, 'password'),
       SMTP_USERNAME: aws_ecs.Secret.fromSecretsManager(smtpSecrets, 'username'),

--- a/ckan/templates/ckan.ini.j2
+++ b/ckan/templates/ckan.ini.j2
@@ -27,6 +27,7 @@ beaker.session.cookie_expires = {% if environ('DEV_MODE') == 'true' %}False{% el
 #beaker.session.secure = True
 beaker.session.httponly = True
 beaker.session.type = ext:database
+beaker.session.validate_key = {{ environ('CKAN_BEAKER_SESSION_VALIDATE_KEY') }}
 beaker.session.url = postgresql://{{ environ('DB_CKAN_USER') }}:{{ environ('DB_CKAN_PASS') }}@{{ environ('DB_CKAN_HOST') }}/{{ environ('DB_CKAN') }}
 
 app_instance_uuid = {{ environ('CKAN_APP_INSTANCE_UUID') }}

--- a/docker/.env.ckan.local
+++ b/docker/.env.ckan.local
@@ -4,6 +4,7 @@
 CKAN_SITE_URL="http://localhost"
 CKAN_DRUPAL_SITE_URL="http://nginx"
 CKAN_BEAKER_SESSION_SECRET="9PBdkxokLGWW4M4jeTI25h+4t"
+CKAN_BEAKER_SESSION_VALIDATE_KEY="iPBD4P87SdAXPaDERKXhgtiX4P7xhh"
 CKAN_APP_INSTANCE_UUID="{dc6259b8-f112-4d23-8816-aadcede1895c}"
 CKAN_SITE_ID=default
 CKAN_PLUGINS_DEFAULT="fluent scheming_datasets scheming_groups scheming_organizations"


### PR DESCRIPTION
cookie based session require this, might be true also when they are stored in database.