### PR TITLE
REKDAT-69: Fix dataset mandatory field validation

### DIFF
--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/schemas/dataset.json
@@ -41,6 +41,7 @@
       },
       "label": "Description",
       "display_snippet": null,
+      "validators": "fluent_text required_languages",
       "required_languages": [
         "fi",
         "sv"
@@ -247,7 +248,7 @@
       "display_property": "dc:contributor",
       "display_snippet": "repeating_email.html",
       "form_snippet": "repeating.html",
-      "validators": "repeating_text repeating_email not_empty",
+      "validators": "not_empty repeating_text repeating_email",
       "required": true
     },
     {

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/macros/form.html
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/macros/form.html
@@ -60,7 +60,7 @@ description - Additional description text between the label and the input
   {%- set extra_html = caller() if caller -%}
   {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required, description="") %}
     <div class="multiple-values">
-      {% if value %}
+      {% if value and value != [''] %}
         {% set values = value if value.append else [value] %}
         {% for value_item in values %}
           {% if value_item %}


### PR DESCRIPTION
- Check description required languages
- Check repeating email field emptiness before parsing structure
- Handle corner case in repeating text field where no input is rendered