### PR TITLE
REKDAT-69: Fix dataset validation error reporting

### DIFF
--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/form_snippets/fluent_markdown_editor.html
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/form_snippets/fluent_markdown_editor.html
@@ -15,9 +15,9 @@
     placeholder=h.scheming_language_text(field.form_placeholder, lang),
     value=data[field.field_name + '-' + lang]
         or data.get(field.field_name, {})[lang],
-    error=errors[field.field_name + '-' + lang],
+    error=errors[field.field_name],
     attrs=form_attrs,
-    is_required=h.scheming_field_required(field),
+    is_required=lang in field.required_languages,
     description=description
     ) %}
     {%- snippet 'scheming/form_snippets/fluent_help_text.html',

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/form_snippets/fluent_tags_with_autocomplete.html
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/form_snippets/fluent_tags_with_autocomplete.html
@@ -21,7 +21,7 @@
     placeholder=h.scheming_language_text(field.form_placeholder),
     value=data[field.field_name + '-' + lang]
     or ','.join(data.get(field.field_name, {}).get(lang, [])),
-    error=errors[field.field_name + '-' + lang],
+    error=errors[field.field_name],
     classes=['control-full', 'label-on-top', 'rd-select2-tags'],
     attrs=attrs_with_locale,
     is_required=lang in field.required_languages,

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/snippets/errors.html
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/scheming/snippets/errors.html
@@ -1,0 +1,72 @@
+{# shallow copy errors so we can remove processed keys #}
+{%- set unprocessed = errors.copy() -%}
+
+{% block errors_list %}
+<div class="error-explanation alert alert-error">
+  <p>{{ _('The form contains invalid entries:') }}</p>
+  <ul>
+    {% block all_errors %}
+      {%- for field in fields -%}
+        {%- if 'error_snippet' in field -%}
+          {%- set error_snippet = field.error_snippet -%}
+
+          {%- if '/' not in error_snippet -%}
+            {%- set error_snippet = 'scheming/error_snippets/' +
+              error_snippet -%}
+          {%- endif -%}
+
+          {%- snippet error_snippet, unprocessed=unprocessed,
+            field=field, fields=fields,
+            entity_type=entity_type, object_type=object_type -%}
+        {%- endif -%}
+
+        {%- if field.field_name in unprocessed -%}
+          {%- set errors = unprocessed.pop(field.field_name) -%}
+          {%- if 'repeating_subfields' in field %}
+            {%- for se in errors -%}
+              {%- if se -%}
+                <li data-field-label="{{ field.field_name }}-{{ loop.index }}">{{
+                  h.scheming_language_text(field.repeating_label or field.label) }} {{ loop.index }}:
+                  <ul>
+                    {%- for sf in field.repeating_subfields -%}
+                      {%- set se_unprocessed = se.copy() -%}
+
+                      {%- if 'error_snippet' in sf -%}
+                        {%- set sfe_snippet = sf.error_snippet -%}
+
+                        {%- if '/' not in sfe_snippet -%}
+                          {%- set sfe_snippet = 'scheming/error_snippets/' +
+                            sfe_snippet -%}
+                        {%- endif -%}
+
+                        {%- snippet sfe_snippet, unprocessed=se_unprocessed,
+                          field=sf, fields=field.repeating_subfileds,
+                          entity_type=entity_type, object_type=object_type -%}
+                      {%- endif -%}
+
+                      {%- if sf.field_name in se_unprocessed -%}
+                        <li data-field-label="{{ field.field_name }}-{{ loop.index }}-{{ sf.field_name }}">{{
+                          h.scheming_language_text(sf.label) }}:
+                          {{ se_unprocessed[sf.field_name][0] }}</li>
+                      {%- endif -%}
+                    {%- endfor -%}
+                  </ul>
+                </li>
+              {%- endif -%}
+            {%- endfor -%}
+          {%- else -%}
+            <li data-field-label="{{ field.field_name }}">{{
+              h.scheming_language_text(field.label) }}:
+              {{ errors | join(', ') }}</li>
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+
+      {%- for key, errors in unprocessed.items() | sort -%}
+        <li data-field-label="{{ key }}">{{ _(key) }}: {{ errors[0] }}</li>
+      {%- endfor -%}
+    {% endblock %}
+  </ul>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
- Fix `fluent_markdown_editor.html` and `fluent_tags_with_autocomplete` to work with `required_languages` validator
- Override scheming `errors.html` to show all errors instead of just the first one