### PR TITLE
REKDAT-81: Only show ckanext-pages links in footer

### DIFF
--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/helpers.py
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/helpers.py
@@ -10,6 +10,9 @@ from datetime import datetime, timedelta
 import iso8601
 import requests
 
+from ckan.lib.helpers import build_nav_main as ckan_build_nav_main
+from ckanext.pages.plugin import build_pages_nav_main as pages_build_nav_main
+
 
 log = getLogger(__name__)
 _ = toolkit._
@@ -188,3 +191,10 @@ def scheming_category_list(args):
 
 def check_group_selected(val, data):
     return any(x['name'] == val for x in data)
+
+
+def build_nav_main(*args, pages=False):
+    if pages:
+        return pages_build_nav_main(*args)
+    else:
+        return ckan_build_nav_main(*args)

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/plugin.py
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/plugin.py
@@ -49,7 +49,8 @@ class RegistrydataPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_homepage_news': helpers.get_homepage_news,
             'get_homepage_groups': helpers.get_homepage_groups,
             'scheming_category_list': helpers.scheming_category_list,
-            'check_group_selected': helpers.check_group_selected
+            'check_group_selected': helpers.check_group_selected,
+            'build_nav_main': helpers.build_nav_main
         }
 
     # IValidators:

--- a/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/footer.html
+++ b/ckan/ckanext/ckanext-registrydata/ckanext/registrydata/templates/footer.html
@@ -7,7 +7,7 @@
       </div>
       <div class="footer-links">
         <ul class="nav navbar footer-nav">
-          {{ h.build_nav_main() }}
+          {{ h.build_nav_main(pages=True) }}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
- Add a new helper to choose which nav helper to use, CKAN or ckanext-pages
- Only show pages in footer