### PR TITLE
REKDAT-65: Use cookie based sessions to resolve logout issues

### DIFF
--- a/ckan/templates/ckan.ini.j2
+++ b/ckan/templates/ckan.ini.j2
@@ -26,9 +26,8 @@ beaker.session.cookie_expires = {% if environ('DEV_MODE') == 'true' %}False{% el
 # Secure session does not currently work in our environments as ssl is terminated on Load balancerreq
 #beaker.session.secure = True
 beaker.session.httponly = True
-beaker.session.type = ext:database
+beaker.session.type = cookie
 beaker.session.validate_key = {{ environ('CKAN_BEAKER_SESSION_VALIDATE_KEY') }}
-beaker.session.url = postgresql://{{ environ('DB_CKAN_USER') }}:{{ environ('DB_CKAN_PASS') }}@{{ environ('DB_CKAN_HOST') }}/{{ environ('DB_CKAN') }}
 
 app_instance_uuid = {{ environ('CKAN_APP_INSTANCE_UUID') }}
 


### PR DESCRIPTION
CKAN for some reason generates a new cookie every now and then and the entry in database doesn't match it anymore and therefore user is logged out. This uses the now default ckan session type which seems to resolve the issue. The cookie has the required information encrypted in it and database should not be needed anymore even when scaling horizontally.