### PR TITLE
Export parameter names in stacks, instead of values

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -211,7 +211,7 @@ const NginxStackDev = new NginxStack(app, 'NginxStack-dev', {
     taskMinCapacity: 1,
     taskMaxCapacity: 1
   },
-  authSourceAddresses: RestricteddataParameterStackDev.authSourceAddresses
+  authSourceAddressesParameterName: RestricteddataParameterStackDev.authSourceAddressesParameterName
 })
 
 const SolrStackDev = new SolrStack(app, 'SolrStack-dev', {
@@ -296,12 +296,12 @@ const ShieldStackDev = new ShieldStack(app, 'ShieldStack-dev', {
   bannedIpListParameterName: ShieldParameterStackDev.bannedIpListParameterName,
   whitelistedIpListParameterName: ShieldParameterStackDev.whitelistedIpListParameterName,
   highPriorityCountryCodeListParameterName: ShieldParameterStackDev.highPriorityCountryCodeListParameterName,
-  highPriorityRateLimit: ShieldParameterStackDev.highPriorityRateLimit,
-  rateLimit: ShieldParameterStackDev.rateLimit,
+  highPriorityRateLimitParameterName: ShieldParameterStackDev.highPriorityRateLimitParameterName,
+  rateLimitParameterName: ShieldParameterStackDev.rateLimitParameterName,
   managedRulesParameterName: ShieldParameterStackDev.managedRulesParameterName,
-  snsTopicArn: ShieldParameterStackDev.snsTopicArn,
-  wafAutomationArn: ShieldParameterStackDev.wafAutomationArn,
-  evaluationPeriod: ShieldParameterStackDev.evaluationPeriod
+  snsTopicArnParameterName: ShieldParameterStackDev.snsTopicArnParameterName,
+  wafAutomationArnParameterName: ShieldParameterStackDev.wafAutomationArnParameterName,
+  evaluationPeriodParameterName: ShieldParameterStackDev.evaluationPeriodParameterName
 })
 
 const MonitoringStackDev = new MonitoringStack(app, 'MonitoringStack-dev', {
@@ -441,7 +441,7 @@ const NginxStackProd = new NginxStack(app, 'NginxStack-prod', {
     taskMinCapacity: 1,
     taskMaxCapacity: 1
   },
-  authSourceAddresses: RestricteddataParameterStackProd.authSourceAddresses
+  authSourceAddressesParameterName: RestricteddataParameterStackProd.authSourceAddressesParameterName
 })
 
 const SolrStackProd = new SolrStack(app, 'SolrStack-prod', {
@@ -527,12 +527,12 @@ const ShieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
   bannedIpListParameterName: ShieldParameterStackProd.bannedIpListParameterName,
   whitelistedIpListParameterName: ShieldParameterStackProd.whitelistedIpListParameterName,
   highPriorityCountryCodeListParameterName: ShieldParameterStackProd.highPriorityCountryCodeListParameterName,
-  highPriorityRateLimit: ShieldParameterStackProd.highPriorityRateLimit,
-  rateLimit: ShieldParameterStackProd.rateLimit,
+  highPriorityRateLimitParameterName: ShieldParameterStackProd.highPriorityRateLimitParameterName,
+  rateLimitParameterName: ShieldParameterStackProd.rateLimitParameterName,
   managedRulesParameterName: ShieldParameterStackProd.managedRulesParameterName,
-  snsTopicArn: ShieldParameterStackProd.snsTopicArn,
-  wafAutomationArn: ShieldParameterStackProd.wafAutomationArn,
-  evaluationPeriod: ShieldParameterStackProd.evaluationPeriod
+  snsTopicArnParameterName: ShieldParameterStackProd.snsTopicArnParameterName,
+  wafAutomationArnParameterName: ShieldParameterStackProd.wafAutomationArnParameterName,
+  evaluationPeriodParameterName: ShieldParameterStackProd.evaluationPeriodParameterName
 })
 
 const MonitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {

--- a/cdk/lib/nginx-stack-props.ts
+++ b/cdk/lib/nginx-stack-props.ts
@@ -1,5 +1,5 @@
 import {EcsStackProps} from "./ecs-stack-props";
-import {aws_certificatemanager, aws_elasticloadbalancingv2, aws_route53, aws_ssm} from "aws-cdk-lib";
+import {aws_certificatemanager, aws_elasticloadbalancingv2, aws_route53} from "aws-cdk-lib";
 
 export interface NginxStackProps extends EcsStackProps {
   allowRobots: string,
@@ -12,5 +12,5 @@ export interface NginxStackProps extends EcsStackProps {
   secondaryDomainName: string,
   fqdn: string,
   secondaryFqdn: string,
-  authSourceAddresses: aws_ssm.IStringListParameter
+  authSourceAddressesParameterName: string
 }

--- a/cdk/lib/restricteddata-parameter-stack.ts
+++ b/cdk/lib/restricteddata-parameter-stack.ts
@@ -4,15 +4,17 @@ import {Construct} from "constructs";
 import {EnvStackProps} from "./env-stack-props";
 
 export class RestricteddataParameterStack extends Stack {
-  readonly authSourceAddresses: aws_ssm.IStringListParameter;
+  readonly authSourceAddressesParameterName: string;
 
   constructor(scope: Construct, id: string, props: EnvStackProps ) {
     super(scope, id, props);
 
-    this.authSourceAddresses = new aws_ssm.StringListParameter(this, 'authSourceAddresses', {
+    this.authSourceAddressesParameterName = `/${props.environment}/restricteddata/auth_source_addresses`
+
+    const authSourceAddresses = new aws_ssm.StringListParameter(this, 'authSourceAddresses', {
       stringListValue: ['127.0.0.1'],
       description: 'Authentication source IP address list',
-      parameterName: `/${props.environment}/restricteddata/auth_source_addresses`
+      parameterName: this.authSourceAddressesParameterName
     })
   }
 }

--- a/cdk/lib/shield-parameter-stack.ts
+++ b/cdk/lib/shield-parameter-stack.ts
@@ -7,12 +7,12 @@ export class ShieldParameterStack extends Stack {
   readonly bannedIpListParameterName: string;
   readonly whitelistedIpListParameterName: string;
   readonly highPriorityCountryCodeListParameterName: string;
-  readonly highPriorityRateLimit: aws_ssm.IStringParameter;
-  readonly rateLimit: aws_ssm.IStringParameter;
+  readonly highPriorityRateLimitParameterName: string;
+  readonly rateLimitParameterName: string;
   readonly managedRulesParameterName: string;
-  readonly wafAutomationArn: aws_ssm.IStringParameter;
-  readonly snsTopicArn: aws_ssm.IStringParameter;
-  readonly evaluationPeriod: aws_ssm.IStringParameter;
+  readonly wafAutomationArnParameterName: string;
+  readonly snsTopicArnParameterName: string;
+  readonly evaluationPeriodParameterName: string;
 
   constructor(scope: Construct, id: string, props: EnvStackProps ) {
     super(scope, id, props);
@@ -38,16 +38,18 @@ export class ShieldParameterStack extends Stack {
       parameterName: this.highPriorityCountryCodeListParameterName
     })
 
-    this.highPriorityRateLimit = new aws_ssm.StringParameter(this, 'highPriorityRateLimit', {
+    this.highPriorityRateLimitParameterName = `/${props.environment}/waf/high_priority_rate_limit`
+    new aws_ssm.StringParameter(this, 'highPriorityRateLimit', {
       stringValue: '0',
       description: 'Rate limit for high priority country codes',
-      parameterName: `/${props.environment}/waf/high_priority_rate_limit`
+      parameterName: this.highPriorityRateLimitParameterName
     })
 
-    this.rateLimit = new aws_ssm.StringParameter(this, 'rateLimit', {
+    this.rateLimitParameterName = `/${props.environment}/waf/rate_limit`
+    new aws_ssm.StringParameter(this, 'rateLimit', {
       stringValue: '0',
       description: 'Rate limit for others',
-      parameterName: `/${props.environment}/waf/rate_limit`
+      parameterName: this.rateLimitParameterName
     })
 
     this.managedRulesParameterName = `/${props.environment}/waf/managed_rules`
@@ -57,22 +59,25 @@ export class ShieldParameterStack extends Stack {
       parameterName: this.managedRulesParameterName
     })
 
-    this.wafAutomationArn = new aws_ssm.StringParameter(this, 'wafAutomationArn', {
+    this.wafAutomationArnParameterName = `/${props.environment}/waf/waf_automation_arn`,
+    new aws_ssm.StringParameter(this, 'wafAutomationArn', {
       stringValue: 'some placeholder',
       description: 'Arn of waf automation lambda',
-      parameterName: `/${props.environment}/waf/waf_automation_arn`,
+      parameterName: this.wafAutomationArnParameterName
     })
 
-    this.snsTopicArn = new aws_ssm.StringParameter(this, 'snsTopicArn', {
+    this.snsTopicArnParameterName = `/${props.environment}/waf/sns_topic_arn`
+    new aws_ssm.StringParameter(this, 'snsTopicArn', {
       stringValue: 'some placeholder',
       description: 'Arn of sns topic',
-      parameterName: `/${props.environment}/waf/sns_topic_arn`,
+      parameterName: this.snsTopicArnParameterName
     })
 
-    this.evaluationPeriod = new aws_ssm.StringParameter(this, 'evaluationPeriod', {
+    this.evaluationPeriodParameterName = `/${props.environment}/waf/evaluation_period`
+    new aws_ssm.StringParameter(this, 'evaluationPeriod', {
       stringValue: '0',
       description: 'Evaluation period for rate limits',
-      parameterName: `/${props.environment}/waf/evaluation_period`
+      parameterName: this.evaluationPeriodParameterName
     })
   }
 }

--- a/cdk/lib/shield-stack-props.ts
+++ b/cdk/lib/shield-stack-props.ts
@@ -11,11 +11,11 @@ export interface ShieldStackProps extends EnvStackProps {
   bannedIpListParameterName: string,
   whitelistedIpListParameterName: string,
   highPriorityCountryCodeListParameterName: string,
-  highPriorityRateLimit: aws_ssm.IStringParameter,
-  rateLimit: aws_ssm.IStringParameter,
+  highPriorityRateLimitParameterName: string,
+  rateLimitParameterName: string,
   managedRulesParameterName: string,
-  wafAutomationArn: aws_ssm.IStringParameter,
-  snsTopicArn: aws_ssm.IStringParameter,
-  evaluationPeriod: aws_ssm.IStringParameter
+  wafAutomationArnParameterName: string,
+  snsTopicArnParameterName: string,
+  evaluationPeriodParameterName: string
 
 }

--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -53,6 +53,16 @@ export class ShieldStack extends Stack {
       default: props.highPriorityCountryCodeListParameterName
     });
 
+    const highPriorityRateLimit = aws_ssm.StringParameter.fromStringParameterAttributes(this,
+      'highPriorityRateLimit', {
+        parameterName: props.highPriorityRateLimitParameterName,
+        simpleName: false
+      })
+
+    const rateLimit = aws_ssm.StringParameter.fromStringParameterAttributes(this, 'rateLimit', {
+      parameterName: props.rateLimitParameterName,
+      simpleName: false
+    })
 
     let rules = [
       {
@@ -122,7 +132,7 @@ export class ShieldStack extends Stack {
         },
         statement: {
           rateBasedStatement: {
-            limit: Token.asNumber(props.highPriorityRateLimit.stringValue),
+            limit: Token.asNumber(highPriorityRateLimit.stringValue),
             aggregateKeyType: "IP",
             scopeDownStatement: {
               geoMatchStatement: {
@@ -146,7 +156,7 @@ export class ShieldStack extends Stack {
         },
         statement: {
           rateBasedStatement: {
-            limit: Token.asNumber(props.rateLimit.stringValue),
+            limit: Token.asNumber(rateLimit.stringValue),
             aggregateKeyType: "IP",
             scopeDownStatement: {
               notStatement: {
@@ -298,9 +308,21 @@ export class ShieldStack extends Stack {
       webAclArn: cfnWebAcl.attrArn
     })
 
-    const WafAutomationLambdaFunction = aws_lambda.Function.fromFunctionArn(this, "WafAutomation", props.wafAutomationArn.stringValue)
+    const wafAutomationArn = aws_ssm.StringParameter.fromStringParameterAttributes(this,
+      'wafAutomationArn', {
+        parameterName: props.wafAutomationArnParameterName,
+        simpleName: false
+      })
 
-    const topic =  aws_sns.Topic.fromTopicArn(this, "SNSTopic", props.snsTopicArn.stringValue)
+    const WafAutomationLambdaFunction = aws_lambda.Function.fromFunctionArn(this, "WafAutomation", wafAutomationArn.stringValue)
+
+    const snsTopicArn = aws_ssm.StringParameter.fromStringParameterAttributes(this,
+      'snsTopicArn', {
+        parameterName: props.snsTopicArnParameterName,
+        simpleName: false
+      })
+
+    const topic =  aws_sns.Topic.fromTopicArn(this, "SNSTopic", snsTopicArn.stringValue)
 
     topic.addSubscription(new aws_sns_subscriptions.LambdaSubscription(WafAutomationLambdaFunction))
 


### PR DESCRIPTION
When parameters are referenced between stacks as parameters, cdk exports them as values and updating the value causes references to replace which breaks automatic deployments. This change exports only the parameter names between stacks so replacement happens only if the name is changed. 